### PR TITLE
STORM-2693: Added in support for worker token auth to supervisor

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/cluster/DaemonType.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/DaemonType.java
@@ -57,6 +57,8 @@ public enum DaemonType {
             }
             switch (type) {
                 case NIMBUS:
+                    //Fall through on purpose
+                case SUPERVISOR:
                     return ZooDefs.Ids.CREATOR_ALL_ACL;
                 case DRPC:
                     List<ACL> ret = new ArrayList<>(ZooDefs.Ids.CREATOR_ALL_ACL);

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
@@ -83,7 +83,8 @@ public class ServerCallbackHandler implements CallbackHandler {
 
         if (ac != null) {
             String authenticationID = ac.getAuthenticationID();
-            LOG.info("Successfully authenticated client: authenticationID=" + authenticationID + " authorizationID= " + ac.getAuthorizationID());
+            LOG.debug("Successfully authenticated client: authenticationID={}  authorizationID= {}", authenticationID,
+                ac.getAuthorizationID());
 
             //if authorizationId is not set, set it to authenticationId.
             if (ac.getAuthorizationID() == null) {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3021,6 +3021,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
             IStormClusterState state = stormClusterState;
 
+            if (creds == null && workerTokenManager != null) {
+                //Make sure we can store the worker tokens even if no creds are provided.
+                creds = new HashMap<>();
+            }
             if (creds != null) {
                 Map<String, Object> finalConf = Collections.unmodifiableMap(topoConf);
                 for (INimbusCredentialPlugin autocred: nimbusAutocredPlugins) {


### PR DESCRIPTION
The only changes that absolutely had to be made were to DaemonType.

The logging change was just because the new heartbeats make it show up so frequently it was painful.

The change to nimbus was a bug in my original patch for worker tokens.  I can split it to a separate JIRA if needed.